### PR TITLE
Added '#include <string>' in misc.h for '__APPLE__' - fixes several errors when compiling on mac

### DIFF
--- a/opencog/util/misc.h
+++ b/opencog/util/misc.h
@@ -31,6 +31,10 @@
 #include <iterator>
 #include <functional>
 
+#ifdef __APPLE__
+#include <string>
+#endif
+
 #ifndef WIN32
 #include <cxxabi.h>
 #endif


### PR DESCRIPTION
This does not make it compile completely, but is a significant first step. May add more commits to this request if/when I determine the other needed changes.

Thanks!