### PR TITLE
Randgen inherit stl random generator

### DIFF
--- a/opencog/util/RandGen.h
+++ b/opencog/util/RandGen.h
@@ -53,9 +53,6 @@ public:
 
     virtual ~RandGen() {}
 
-    //! reset the random seed
-    virtual void seed(unsigned long) = 0;
-    
     //! random int between 0 and max rand number.
     virtual int randint() = 0;
 

--- a/opencog/util/RandGen.h
+++ b/opencog/util/RandGen.h
@@ -37,6 +37,15 @@ namespace opencog
  */
 
 //! interface for random generators
+    
+// RandGen inherits std::mt19937. This may seem like a hack because
+// there is no point having that abstract class inherit a concrete
+// random generator. But it's clear we don't need that home made
+// random generator structure anymore so it's a step toward getting
+// rid of it.
+//
+// The advantage is that the random generator returned by the
+// singleton randGen() can be now used in the STL distributions.
 class RandGen : public std::mt19937
 {
 

--- a/opencog/util/RandGen.h
+++ b/opencog/util/RandGen.h
@@ -28,6 +28,7 @@
 #include <set>
 #include <vector>
 #include <opencog/util/exceptions.h>
+#include <random>
 
 namespace opencog
 {
@@ -36,7 +37,7 @@ namespace opencog
  */
 
 //! interface for random generators
-class RandGen
+class RandGen : public std::mt19937
 {
 
 public:

--- a/opencog/util/mt19937ar.cc
+++ b/opencog/util/mt19937ar.cc
@@ -36,34 +36,34 @@ using namespace opencog;
 // PUBLIC METHODS: 
 
 MT19937RandGen::MT19937RandGen(unsigned long s) {
-    randomGen.seed(s);
+    seed(s);
 }
 
 
 void MT19937RandGen::seed(unsigned long s) {
-    randomGen.seed(s);
+    std::mt19937::seed(s);
 }
 
 // random int between 0 and max rand number.
 int MT19937RandGen::randint() {
     std::uniform_int_distribution<int> dis;
-    return dis(randomGen);
+    return dis(*this);
 }
 
 // random float in [0,1]
 float MT19937RandGen::randfloat() {
-    return randomGen() / (float)randomGen.max();
+    return operator()() / (float)max();
 }
 
 // random double in [0,1]
 double MT19937RandGen::randdouble() {
-    return randomGen() / (double)randomGen.max();
+	return operator()() / (double)max();
 }
   
 //random double in [0,1)
 double MT19937RandGen::randDoubleOneExcluded() {
     std::uniform_real_distribution<double> dis;
-    return dis(randomGen);
+    return dis(*this);
 }
 
 //random int in [0,n)
@@ -73,7 +73,7 @@ int MT19937RandGen::randint(int n) {
 
 // return -1 or 1 randonly
 int MT19937RandGen::randPositiveNegative(){
-    return (this->randint(2) == 0) ? 1 : -1;
+    return (randint(2) == 0) ? 1 : -1;
 }
 
 //random boolean
@@ -85,7 +85,7 @@ bool MT19937RandGen::randbool() {
 int MT19937RandGen::randDiscrete(const std::vector<double>& weights)
 {
     std::discrete_distribution<int> distribution(weights.begin(), weights.end());
-    return distribution(randomGen);
+    return distribution(*this);
 }
 
 

--- a/opencog/util/mt19937ar.cc
+++ b/opencog/util/mt19937ar.cc
@@ -40,10 +40,6 @@ MT19937RandGen::MT19937RandGen(unsigned long s) {
 }
 
 
-void MT19937RandGen::seed(unsigned long s) {
-    std::mt19937::seed(s);
-}
-
 // random int between 0 and max rand number.
 int MT19937RandGen::randint() {
     std::uniform_int_distribution<int> dis;

--- a/opencog/util/mt19937ar.h
+++ b/opencog/util/mt19937ar.h
@@ -38,9 +38,6 @@ public:
 
     MT19937RandGen(unsigned long s);
 
-    //! reset the random seed
-    void seed(unsigned long); 
-    
     //! random int between 0 and max rand number.
     int randint();
 

--- a/opencog/util/mt19937ar.h
+++ b/opencog/util/mt19937ar.h
@@ -34,11 +34,6 @@ namespace opencog
 
 class MT19937RandGen : public RandGen
 {
-
-private: 
-
-    std::mt19937 randomGen;
-
 public: 
 
     MT19937RandGen(unsigned long s);


### PR DESCRIPTION
Since the random generator fully relies on STL I decided to have RandGen directly inherits std::mt19937. That way one can use the generator returned by the singleton randGen() in STL distributions.

I would have preferred to have MT19937RandGen inherit std::mt19937 rather than randGen() but I couldn't because RandGen is the abstract generator class used all over in OpenCog, and as far as I can tell there is no abstract STL generator one could use for that.

The next step would be to get rid of RandGen and MT19937RandGen, only keep rangGen() that would return an std::mt19937 generator (or any STL generator), but that involves changing the all callers. Maybe that's not worth it. The most important is that we can now use STL distributions.