### PR TITLE
use include/opencog/util as install path

### DIFF
--- a/opencog/util/CMakeLists.txt
+++ b/opencog/util/CMakeLists.txt
@@ -118,7 +118,7 @@ INSTALL(FILES
 	StringTokenizer.h
 	tbb.h
 	tree.h
-	DESTINATION "include/${PROJECT_NAME}/util"
+	DESTINATION "include/opencog/util"
 )
 
 IF (WIN32)


### PR DESCRIPTION
The other option, that I know of, is to refactor all dependent project's preprocessor declarations. That maybe the 'right' thing to do, I don't know, or revert the project name change.