### PR TITLE
Lazy logger

### DIFF
--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -301,11 +301,11 @@ private:
 Logger& logger();
 
 // Macro to not evaluate the stream if log level is disabled
-#define LAZY_LOGGER_ERROR if(logger().isErrorEnabled()) logger().error()
-#define LAZY_LOGGER_WARN if(logger().isWarnEnabled()) logger().warn()
-#define LAZY_LOGGER_INFO if(logger().isInfoEnabled()) logger().info()
-#define LAZY_LOGGER_DEBUG if(logger().isDebugEnabled()) logger().debug()
-#define LAZY_LOGGER_FINE if(logger().isFineEnabled()) logger().fine()
+#define LAZY_LOG_ERROR if(logger().isErrorEnabled()) logger().error()
+#define LAZY_LOG_WARN if(logger().isWarnEnabled()) logger().warn()
+#define LAZY_LOG_INFO if(logger().isInfoEnabled()) logger().info()
+#define LAZY_LOG_DEBUG if(logger().isDebugEnabled()) logger().debug()
+#define LAZY_LOG_FINE if(logger().isFineEnabled()) logger().fine()
 
 /** @}*/
 }  // namespace opencog

--- a/opencog/util/Logger.h
+++ b/opencog/util/Logger.h
@@ -300,6 +300,13 @@ private:
 // singleton instance (following Meyer's design pattern)
 Logger& logger();
 
+// Macro to not evaluate the stream if log level is disabled
+#define LAZY_LOGGER_ERROR if(logger().isErrorEnabled()) logger().error()
+#define LAZY_LOGGER_WARN if(logger().isWarnEnabled()) logger().warn()
+#define LAZY_LOGGER_INFO if(logger().isInfoEnabled()) logger().info()
+#define LAZY_LOGGER_DEBUG if(logger().isDebugEnabled()) logger().debug()
+#define LAZY_LOGGER_FINE if(logger().isFineEnabled()) logger().fine()
+
 /** @}*/
 }  // namespace opencog
 

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -137,4 +137,17 @@ public:
         logAllLevels("LoggerUTest.fine.log",  Logger::FINE,  5);
     }
 
+    void testLazyLogger()
+    {
+        logger().setLevel(Logger::DEBUG);
+
+        int i = 0;
+
+        LAZY_LOGGER_FINE << "i = " << ++i;
+        LAZY_LOGGER_DEBUG << "i = " << ++i;
+        LAZY_LOGGER_INFO << "i = " << ++i;
+
+        TS_ASSERT_EQUALS(i, 2);
+    }
+
 }; // class

--- a/tests/util/LoggerUTest.cxxtest
+++ b/tests/util/LoggerUTest.cxxtest
@@ -143,9 +143,9 @@ public:
 
         int i = 0;
 
-        LAZY_LOGGER_FINE << "i = " << ++i;
-        LAZY_LOGGER_DEBUG << "i = " << ++i;
-        LAZY_LOGGER_INFO << "i = " << ++i;
+        LAZY_LOG_FINE << "i = " << ++i;
+        LAZY_LOG_DEBUG << "i = " << ++i;
+        LAZY_LOG_INFO << "i = " << ++i;
 
         TS_ASSERT_EQUALS(i, 2);
     }


### PR DESCRIPTION
Fix for issue #20 

The usage is simple
```c++
LAZY_LOG_DEBUG << foo();
```
If the debug level is below DEBUG then foo() is not executed, unlike
```c++
logger().debug() << foo();
```

I choose to keep the LAZY prefix in the macro to help the user to understand the difference between logger().debug() and LAZY_LOG_DEBUG.