### PR TITLE
Fix typo in README.md

### DIFF
--- a/doc/README.archlinux
+++ b/doc/README.archlinux
@@ -18,7 +18,7 @@ if so just compile it manually and it should work.
 
 ----------------------------------------------------------
 
-Opencog depends on a few packages. These are:
+OpenCog depends on a few packages. These are:
 
    g++ cmake boost cxxtest
 


### PR DESCRIPTION
OpenCog was mis-typed as Opencog 