### PR TITLE
Add hack to run the cogserver from scripts/run_cogserver.sh

### DIFF
--- a/opencog/util/files.cc
+++ b/opencog/util/files.cc
@@ -66,6 +66,10 @@ static const std::vector<std::string> paths =
     "../../../",
     "../../../../",   // some unit tests need this
 #endif // !WIN32
+    // This is useful for loading the cogserver from repository root
+    // or scripts directories
+    "build/",
+    "../build/",
     CMAKE_INSTALL_PREFIX "/lib",
     CMAKE_INSTALL_PREFIX "/share",
     DATADIR,         // this too is an install dir


### PR DESCRIPTION
assuming that user has compiled opencog under a directory called build.

Hack/fix for issue #47