### PR TITLE
Read OPENCOG_MODULE_PATHS env var for user defined module paths

### DIFF
--- a/opencog/util/files.cc
+++ b/opencog/util/files.cc
@@ -33,6 +33,9 @@
 #include "files.h"
 #include "platform.h"
 
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+
 #ifdef WIN32_NOT_UNIX
 #include <direct.h>
 #define  mkdir _mkdir
@@ -43,6 +46,7 @@
 #define PATH_MAX 1024
 #endif
 
+
 #define USER_FLAG "$USER"
 
 /**
@@ -51,6 +55,9 @@
  *
  * The basic search algo is that anything in the user's directory is
  * explored first, before anything in the system directories.
+ *
+ * The user can set the environmental OPENCOG_MODULE_PATHS to add more
+ * module paths after compile time.
  */
 static const std::vector<std::string> paths =
 {
@@ -66,10 +73,6 @@ static const std::vector<std::string> paths =
     "../../../",
     "../../../../",   // some unit tests need this
 #endif // !WIN32
-    // This is useful for loading the cogserver from repository root
-    // or scripts directories
-    "build/",
-    "../build/",
     CMAKE_INSTALL_PREFIX "/lib",
     CMAKE_INSTALL_PREFIX "/share",
     DATADIR,         // this too is an install dir
@@ -83,6 +86,19 @@ static const std::vector<std::string> paths =
 #endif // !WIN32
 };
 const std::vector<std::string> opencog::DEFAULT_MODULE_PATHS = paths;
+
+std::vector<std::string> opencog::get_module_paths()
+{
+	std::vector<std::string> results = opencog::DEFAULT_MODULE_PATHS;
+	if (const char* env_p = std::getenv("OPENCOG_MODULE_PATHS"))
+	{
+		std::vector<std::string> split_paths;
+		std::string paths(env_p);
+		boost::split(split_paths, paths, boost::is_any_of(":"));
+		results.insert(results.end(), split_paths.begin(), split_paths.end());
+	}
+	return results;
+}
 
 bool opencog::file_exists(const char* filename)
 {

--- a/opencog/util/files.h
+++ b/opencog/util/files.h
@@ -46,6 +46,13 @@ namespace opencog
 extern const std::vector<std::string> DEFAULT_MODULE_PATHS;
 
 /**
+ * Return the set pf paths to search when attempting to a module based
+ * on DEFAULT_MODULE_PATHS and the environment variable
+ * OPENCOG_MODULE_PATHS.
+ */
+std::vector<std::string> get_module_paths();
+
+/**
  * Check if a file exists in the current directory
  *
  * @param filename The name of the file to check if it exists.


### PR DESCRIPTION
I also removed the hardwired path with build. I don't know if that's ultimately the right thing to do to address #47 but I didn't like the fact that run_cogserver.sh can't deal with build dir with different names than `build`, and whatnot.