### PR TITLE
Fix gcc-6 build error

### DIFF
--- a/opencog/util/functional.h
+++ b/opencog/util/functional.h
@@ -12,6 +12,8 @@
 #include <boost/utility/result_of.hpp>
 #include <boost/utility/addressof.hpp>
 
+#include <vector>
+
 #include <ext/functional>
 
 namespace opencog


### PR DESCRIPTION
The error message was
````
/usr/local/include/opencog/util/functional.h:41:6: error: ‘vector’ in namespace ‘std’ does not name a template type
````