### PR TITLE
Initial prototype of a fast signal function

### DIFF
--- a/opencog/util/CMakeLists.txt
+++ b/opencog/util/CMakeLists.txt
@@ -114,6 +114,7 @@ INSTALL(FILES
 	ranking.h
 	recent_val.h
 	selection.h
+	sigslot.h
 	StringManipulator.h
 	StringTokenizer.h
 	tbb.h

--- a/opencog/util/sigslot.h
+++ b/opencog/util/sigslot.h
@@ -1,0 +1,70 @@
+#ifndef __COGUTIL_SIGSLOT_H__
+#define __COGUTIL_SIGSLOT_H__
+
+#include <functional>
+#include <map>
+#include <mutex>
+
+// A signal-slot class, to replace boost::signals2, which is painfully
+// over-weight, complex and slow. (Try it -- launch gdb, get into the
+// signal, and look at the stack. boost::signals2 uses eleven stack
+// frames to do its thing. Eleven! Really!) So this class avoids that.
+//
+// We don't need anything fancy; this is super-minimalist in design.
+// It is thread-safe.  It works!
+//
+// Example usage:
+//
+// void foo(int x, std::vector<int> y) {
+//    printf ("ola %d (%d) [%d %d %d]\n", x, y.size(), y[0], y[1], y[2]);
+// }
+//
+// SigSlot<int, std::vector<int>> siggy;
+// siggy.connect(foo);
+// siggy.emit(42, {68,69,70});
+//
+
+template <typename... ARGS>
+class SigSlot
+{
+	private:
+		mutable std::mutex _mtx;
+		// HACK ALERT -- use std::map, not std::set here, for only
+		// one reason: so that we get a natural operator-less, which
+		// is needed for the insert() to work. 
+		mutable std::map<int, std::function<void(ARGS...)>> _slots;
+		mutable int _slot_id;
+
+	public:
+		SigSlot() : _slot_id(0) {}
+
+		// Connect using std::function.
+		int connect(std::function<void(ARGS...)> const& fn)
+		{
+			std::lock_guard<std::mutex> lck(_mtx);
+			_slot_id++;
+			_slots.insert(std::make_pair(_slot_id, fn));
+			return _slot_id;
+		}
+
+		void disconnect(int id)
+		{
+			std::lock_guard<std::mutex> lck(_mtx);
+			_slots.erase(id);
+		}
+
+		void disconnect_all()
+		{
+			std::lock_guard<std::mutex> lck(_mtx);
+			_slots.clear();
+		}
+
+		// Call everything that's connected.
+		void emit(ARGS... p)
+		{
+			std::lock_guard<std::mutex> lck(_mtx);
+			for(auto it : _slots) it.second(p...);
+		}
+};
+
+#endif /* __COGUTIL_SIGSLOT_H__ */


### PR DESCRIPTION
Boost::signals2 are incredibly slow, and account for 5% or 10% of the total atomspace performance. This is a step to try to remedy that icky situation.