### PR TITLE
Add a write buffer, and a concurrent set.

### DIFF
--- a/opencog/util/CMakeLists.txt
+++ b/opencog/util/CMakeLists.txt
@@ -73,6 +73,7 @@ ADD_SUBDIRECTORY(boost_ext)
 INSTALL(FILES
 	ansi.h
 	algorithm.h
+	async_buffer.h
 	async_method_caller.h
 	backtrace-symbols.h
 	based_variant.h

--- a/opencog/util/CMakeLists.txt
+++ b/opencog/util/CMakeLists.txt
@@ -83,6 +83,7 @@ INSTALL(FILES
 	Counter.h
 	Cover_Tree.h
 	concurrent_queue.h
+	concurrent_set.h
 	concurrent_stack.h
 	digraph.h
 	dorepeat.h

--- a/opencog/util/async_buffer.h
+++ b/opencog/util/async_buffer.h
@@ -158,6 +158,10 @@ class async_buffer
 
 		unsigned long get_busy_writers() const { return _busy_writers; }
 		unsigned long get_size() const { return _store_set.size(); }
+		unsigned long get_high_watermark() const { return _high_watermark; }
+		unsigned long get_low_watermark() const { return _low_watermark; }
+		bool stalling() const { return _stall_writers; }
+
 		void clear_stats();
 };
 

--- a/opencog/util/async_method_caller.h
+++ b/opencog/util/async_method_caller.h
@@ -312,7 +312,7 @@ void async_caller<Writer, Element>::write_loop()
 /**
  * Enqueue the given element.  Returns immediately after enqueuing.
  * Thread-safe: this may be called concurrently from multiple threads.
- * If the queue is over-full, then this will block until the que is
+ * If the queue is over-full, then this will block until the queue is
  * mostly drained...
  */
 template<typename Writer, typename Element>

--- a/opencog/util/async_method_caller.h
+++ b/opencog/util/async_method_caller.h
@@ -178,6 +178,15 @@ async_caller<Writer, Element>::~async_caller()
 	stop_writer_threads();
 }
 
+/// Set the high and low watermarks for processing. These are useful
+/// for preventing excessive backlogs of unprocessed elements from
+/// accumulating. When enqueueing new work, any threads that encounter
+/// an unprocessed backlog exceeding the high watermark will block
+/// until the backlog drops below the low watermark.  Note that if
+/// some threads are blocked, waiting for this drain to occur, that
+/// this does not prevent other threads from adding more work, as long
+/// as those other threads did not see a large backlog.
+///
 template<typename Writer, typename Element>
 void async_caller<Writer, Element>::set_watermarks(size_t hi, size_t lo)
 {

--- a/opencog/util/async_method_caller.h
+++ b/opencog/util/async_method_caller.h
@@ -134,6 +134,8 @@ class async_caller
 
 		unsigned long get_busy_writers() const { return _busy_writers; }
 		unsigned long get_queue_size() const { return _store_queue.size(); }
+		unsigned long get_high_watermark() const { return _high_watermark; }
+		unsigned long get_low_watermark() const { return _low_watermark; }
 		void clear_stats();
 };
 

--- a/opencog/util/async_method_caller.h
+++ b/opencog/util/async_method_caller.h
@@ -366,7 +366,7 @@ void async_caller<Writer, Element>::enqueue(const Element& elt)
 	// If the writer threads are falling behind, mitigate.
 	// Right now, this will be real simple: just spin and wait
 	// for things to catch up.  Maybe we should launch more threads!?
-	// Note also: even as we block this thread, wiating for the drain
+	// Note also: even as we block this thread, waiting for the drain
 	// to complete, other threads might be filling the queue back up.
 	// If it does over-fill, then those threads will also block, one
 	// by one, until we hit a metastable state, where the active

--- a/opencog/util/async_method_caller.h
+++ b/opencog/util/async_method_caller.h
@@ -97,6 +97,8 @@ class async_caller
 		std::mutex _write_mutex;
 		std::mutex _enqueue_mutex;
 		std::atomic<unsigned long> _busy_writers;
+		size_t _high_watermark;
+		size_t _low_watermark;
 
 		Writer* _writer;
 		void (Writer::*_do_write)(const Element&);
@@ -114,6 +116,8 @@ class async_caller
 		void enqueue(const Element&);
 		void flush_queue();
 		void barrier();
+
+		void set_watermarks(size_t, size_t);
 
 		// Utilities for monitoring performance.
 		// _item_count == number of items queued;
@@ -138,6 +142,9 @@ class async_caller
 /* ================================================================ */
 // Constructors
 
+#define DEFAULT_HIGH_WATER_MARK 100
+#define DEFAULT_LOW_WATER_MARK 10
+
 /// Writer: the class whose method will be called.
 /// cb: the method that will be called.
 /// nthreads: the number of threads in the writer pool to use. Defaults
@@ -154,6 +161,9 @@ async_caller<Writer, Element>::async_caller(Writer* wr,
 	_busy_writers = 0;
 	_in_drain = false;
 
+	_high_watermark = DEFAULT_HIGH_WATER_MARK;
+	_low_watermark = DEFAULT_LOW_WATER_MARK;
+
 	clear_stats();
 
 	for (int i=0; i<nthreads; i++)
@@ -166,6 +176,13 @@ template<typename Writer, typename Element>
 async_caller<Writer, Element>::~async_caller()
 {
 	stop_writer_threads();
+}
+
+template<typename Writer, typename Element>
+void async_caller<Writer, Element>::set_watermarks(size_t hi, size_t lo)
+{
+	_high_watermark = hi;
+	_low_watermark = lo;
 }
 
 template<typename Writer, typename Element>
@@ -354,10 +371,8 @@ void async_caller<Writer, Element>::enqueue(const Element& elt)
 	// If it does over-fill, then those threads will also block, one
 	// by one, until we hit a metastable state, where the active
 	// (non-stalled) fillers and emptiers are in balance.
-#define HIGH_WATER_MARK 100
-#define LOW_WATER_MARK 10
 
-	if (HIGH_WATER_MARK < _store_queue.size())
+	if (_high_watermark < _store_queue.size())
 	{
 		if (_in_drain) _drain_concurrent ++;
 		else _drain_count++;
@@ -371,7 +386,7 @@ void async_caller<Writer, Element>::enqueue(const Element& elt)
 			// usleep(1000);
 			// cnt++;
 		}
-		while (LOW_WATER_MARK < _store_queue.size());
+		while (_low_watermark < _store_queue.size());
 		_in_drain = false;
 
 		// Sleep might not be accurate, so measure elapsed time directly.

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -36,10 +36,12 @@
  *  @{
  */
 
-//! Represents a thread-safe set.
+//! Represents a thread-safe std::set. Because a set can only ever hold
+/// a single copy of an item, this provides a basic de-duplication
+/// service.
 ///
-/// Implements a thread-safe set: any thread can intsert stuff into the
-/// set, and any other thread can remove stuff from it.  If the set
+/// This implements a thread-safe set: any thread can insert stuff into
+/// the set, and any other thread can remove stuff from it.  If the set
 /// is empty, the thread attempting to remove stuff will block.  If the
 /// set is empty, and something is added to the set, and there is
 /// some thread blocked on the set, then that thread will be woken up.

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -36,23 +36,33 @@
  *  @{
  */
 
-//! Represents a thread-safe first in-first out list.
+//! Represents a thread-safe set.
 ///
-/// Implements a thread-safe queue: any thread can push stuff onto the
-/// queue, and any other thread can remove stuff from it.  If the queue
+/// Implements a thread-safe set: any thread can intsert stuff into the
+/// set, and any other thread can remove stuff from it.  If the set
 /// is empty, the thread attempting to remove stuff will block.  If the
-/// queue is empty, and something is added to the queue, and there is
-/// some thread blocked on the queue, then that thread will be woken up.
+/// set is empty, and something is added to the set, and there is
+/// some thread blocked on the set, then that thread will be woken up.
 ///
 /// The function provided here is almost identical to that provided by
-/// the pool class (also in this directory), but with a fancier API that
-/// allows cancellation, and other minor utilities. This API is also
-/// most easily understood as a producer-consumer API, with producer
-/// threads adding stuff to the queue, and consumer threads removing
-/// them.  By contrast, the pool API is a borrow-and-return API, which
-/// is really more-or-less the same thing, but just uses a different
-/// mindset.  This API also matches the proposed C++ standard for this
-/// basic idea.
+/// the concurrent_stack/concurrent_queue classes (in this directory)
+/// except that the class behaves like a set: an item can be inserted
+/// into the set many times, and, if its not removed, then it will only
+/// ever appear in it once.  In essence, it avoids redundancy, as
+/// compared to items placed in a queue/stack.
+///
+/// In other respects, it behaves like the concurrent queue/stack
+/// classes: when an item is gotten, it is removed (erased) from the set.
+/// It employes the same cancellation and condition-wait mechanisms
+/// as those classes, thus ensuring proper concurrency.
+///
+/// The Element class must have an std::less associated with it, as that
+/// is used to determine if an element is already in the set.  When
+/// getting elements from the set, they will be gotten from the "front",
+/// i.e. based on what std::less returned.  This means that there are no
+/// round-robin or "fair" fetching guarantees of any sort; in fact, the
+/// gets are guaranteed to NOT be fair.  This may result in unexpected
+/// behavior.
 
 template<typename Element>
 class concurrent_set

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -1,0 +1,221 @@
+/*
+ * opencog/util/concurrent_set.h
+ *
+ * Based off of http://www.justsoftwaresolutions.co.uk/threading/implementing-a-thread-safe-queue-using-condition-variables.html
+ * Original version by Anthony Williams
+ * Modifications by Michael Anderson
+ * Modified by Linas Vepstas
+ * Updated API to more closely resemble the proposed
+ * ISO/IEC JTC1 SC22 WG21 N3533 C++ Concurrent Queues
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OC_CONCURRENT_SET_H
+#define _OC_CONCURRENT_SET_H
+
+#include <condition_variable>
+#include <set>
+#include <exception>
+#include <mutex>
+
+/** \addtogroup grp_cogutil
+ *  @{
+ */
+
+//! Represents a thread-safe first in-first out list.
+///
+/// Implements a thread-safe queue: any thread can push stuff onto the
+/// queue, and any other thread can remove stuff from it.  If the queue
+/// is empty, the thread attempting to remove stuff will block.  If the
+/// queue is empty, and something is added to the queue, and there is
+/// some thread blocked on the queue, then that thread will be woken up.
+///
+/// The function provided here is almost identical to that provided by
+/// the pool class (also in this directory), but with a fancier API that
+/// allows cancellation, and other minor utilities. This API is also
+/// most easily understood as a producer-consumer API, with producer
+/// threads adding stuff to the queue, and consumer threads removing
+/// them.  By contrast, the pool API is a borrow-and-return API, which
+/// is really more-or-less the same thing, but just uses a different
+/// mindset.  This API also matches the proposed C++ standard for this
+/// basic idea.
+
+template<typename Element>
+class concurrent_set
+{
+private:
+    std::set<Element> the_set;
+    mutable std::mutex the_mutex;
+    std::condition_variable the_cond;
+    bool is_canceled;
+
+public:
+    concurrent_set()
+        : the_set(), the_mutex(), the_cond(), is_canceled(false)
+    {}
+    concurrent_set(const concurrent_set&) = delete;  // disable copying
+    concurrent_set& operator=(const concurrent_set&) = delete; // no assign
+
+    struct Canceled : public std::exception
+    {
+        const char * what() { return "Cancellation of wait on concurrent_set"; }
+    };
+
+    /// Insert the Element into the set; copies the item.
+    void insert(const Element& item)
+    {
+        std::unique_lock<std::mutex> lock(the_mutex);
+        if (is_canceled) throw Canceled();
+        the_set.insert(item);
+        lock.unlock();
+        the_cond.notify_one();
+    }
+
+    /// Insert the Element into the set, by moving it.
+    void insert(Element&& item)
+    {
+        std::unique_lock<std::mutex> lock(the_mutex);
+        if (is_canceled) throw Canceled();
+        the_set.insert(std::move(item));
+        lock.unlock();
+        the_cond.notify_one();
+    }
+
+    /// Return true if the set is empty.
+    bool is_empty() const
+    {
+        std::lock_guard<std::mutex> lock(the_mutex);
+        if (is_canceled) throw Canceled();
+        return the_set.empty();
+    }
+
+    /// Return the size of the set.
+    /// Since the set is time-varying, the size may become incorrect
+    /// shortly after this method returns.
+    unsigned int size() const
+    {
+        std::lock_guard<std::mutex> lock(the_mutex);
+        return the_set.size();
+    }
+
+    /// Try to get an element in the set. Return true if success,
+    /// else return false. The element is removed from the set.
+    bool try_get(Element& value)
+    {
+        std::lock_guard<std::mutex> lock(the_mutex);
+        if (is_canceled) throw Canceled();
+        if (the_set.empty())
+        {
+            return false;
+        }
+
+        auto it = the_set.begin();
+        value = *it;
+        the_set.erase(it);
+        return true;
+    }
+
+    /// Get an item from the set. Block if the set is empty.
+    /// The element is remove from the set, before this returns.
+    void get(Element& value)
+    {
+        std::unique_lock<std::mutex> lock(the_mutex);
+
+        // Use two nested loops here.  It can happen that the cond
+        // wakes up, and yet the set is empty.
+        do
+        {
+            while (the_set.empty() and not is_canceled)
+            {
+                the_cond.wait(lock);
+            }
+            if (is_canceled) throw Canceled();
+        }
+        while (the_set.empty());
+
+        auto it = the_set.begin();
+        value = *it;
+        the_set.erase(it);
+    }
+
+    Element get()
+    {
+        Element value;
+        get(value);
+        return value;
+    }
+
+    std::set<Element> wait_and_take_all()
+    {
+        std::unique_lock<std::mutex> lock(the_mutex);
+
+        // Use two nested loops here.  It can happen that the cond
+        // wakes up, and yet the queue is empty.
+        do
+        {
+            while (the_set.empty() and not is_canceled)
+            {
+                the_cond.wait(lock);
+            }
+            if (is_canceled) throw Canceled();
+        }
+        while (the_set.empty());
+
+        std::set<Element> retval;
+        std::swap(retval, the_set);
+        return retval;
+    }
+
+    /// A weak barrier.  This will block as long as the queue is empty,
+    /// returning only when the queue isn't. It's "weak", because while
+    /// it waits, other threads may push and then pop something from
+    /// the queue, while this thread slept the entire time. However,
+    /// if this call does return, then the queue is almost surely not
+    /// empty.  "Almost surely" means that none of the other threads
+    /// that are currently waiting to pop from the queue will be woken.
+    void barrier()
+    {
+        std::unique_lock<std::mutex> lock(the_mutex);
+
+        while (the_set.empty() and not is_canceled)
+        {
+            the_cond.wait(lock);
+        }
+        if (is_canceled) throw Canceled();
+    }
+
+    void cancel_reset()
+    {
+       // This doesn't lose data, but it instead allows new calls
+       // to not throw Canceled exceptions
+       std::lock_guard<std::mutex> lock(the_mutex);
+       is_canceled = false;
+    }
+
+    void cancel()
+    {
+       std::unique_lock<std::mutex> lock(the_mutex);
+       if (is_canceled) throw Canceled();
+       is_canceled = true;
+       lock.unlock();
+       the_cond.notify_all();
+    }
+
+};
+/** @}*/
+
+#endif // __CONCURRENT_SET__

--- a/opencog/util/concurrent_set.h
+++ b/opencog/util/concurrent_set.h
@@ -174,7 +174,7 @@ public:
         std::unique_lock<std::mutex> lock(the_mutex);
 
         // Use two nested loops here.  It can happen that the cond
-        // wakes up, and yet the queue is empty.
+        // wakes up, and yet the set is empty.
         do
         {
             while (the_set.empty() and not is_canceled)
@@ -190,13 +190,13 @@ public:
         return retval;
     }
 
-    /// A weak barrier.  This will block as long as the queue is empty,
-    /// returning only when the queue isn't. It's "weak", because while
-    /// it waits, other threads may push and then pop something from
-    /// the queue, while this thread slept the entire time. However,
-    /// if this call does return, then the queue is almost surely not
+    /// A weak barrier.  This will block as long as the set is empty,
+    /// returning only when the set isn't. It's "weak", because while
+    /// it waits, other threads may insert and then remove something from
+    /// the set, while this thread slept the entire time. However,
+    /// if this call does return, then the set is almost surely not
     /// empty.  "Almost surely" means that none of the other threads
-    /// that are currently waiting to pop from the queue will be woken.
+    /// that are currently waiting to get from the set will be woken.
     void barrier()
     {
         std::unique_lock<std::mutex> lock(the_mutex);


### PR DESCRIPTION
The concurrent set allows multiple threads to safely, concurrently add and remove items from an std::set class. Because an std::set can only ever hold one copy of an item, this provides a basic thread-safe de-duplication service.

The write-buffer implements an asynchronous de-duplicated write-back set. Just like the async method caller, it will call a method on a class asynchronously, in a different thread. Unlike the async caller, this will avoid calling the method more than once for the same block of data.  Thus, its useful for implementing a buffer that avoids un-needed (duplicated) operations, such as writes. 

This buffer is used by the SQL backend to avoid storing values that have not been changed since the last store request.