### PR TITLE
Build fix: changed std::abs() -> std::fabs() to be built with G++ 7.1.0

### DIFF
--- a/opencog/util/numeric.h
+++ b/opencog/util/numeric.h
@@ -285,8 +285,8 @@ template<typename FloatT> bool is_within(FloatT x, FloatT y, FloatT epsilon)
 /// note that, unlike isWithin, the precision adapts with the scale of x and y
 template<typename FloatT> bool is_approx_eq(FloatT x, FloatT y, FloatT epsilon)
 {
-    FloatT diff = std::abs(x - y);
-    FloatT amp = std::abs(x + y);
+    FloatT diff = std::fabs(x - y);
+    FloatT amp = std::fabs(x + y);
     if (amp*amp > epsilon)
         return diff <= epsilon * amp;
     else return diff <= epsilon;


### PR DESCRIPTION
MOSES build with newer(?) G++ fails (see moses PR #49).  Changing abs() to fabs() fixes this.