### PR TITLE
Rename set union inplace to set_insertion

### DIFF
--- a/opencog/util/algorithm.h
+++ b/opencog/util/algorithm.h
@@ -225,9 +225,8 @@ Set set_union(const Set& s1, const Set& s2) {
  * or similar concept.
  */
 template<typename Set>
-Set set_union(Set& s1, const Set& s2) {
+void set_insertion(Set& s1, const Set& s2) {
     s1.insert(s2.begin(), s2.end());
-    return s1;
 }
 
 /**


### PR DESCRIPTION
Actual fix for https://github.com/opencog/opencog/issues/2889

Linas fix where creating ambiguity (just like the previously), kinda dangerous cause you wouldn't know whether the compiler would choose the version that modifies the input or the version that doesn't. I renamed it so that no ambiguity is possible.